### PR TITLE
Add option to skip embedding KeyInfo

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -49,24 +49,25 @@ const sign = (xml, opts) => {
 
   sig.signingKey = privatekey
 
-  sig.keyInfoProvider = {
-    getKeyInfo: (key, prefix) => {
-      prefix = prefix ? prefix + ':' : ''
-      return (
-        '<' +
-        prefix +
-        'X509Data><' +
-        prefix +
-        'X509Certificate>' +
-        pemToCert(cert) +
-        '</' +
-        prefix +
-        'X509Certificate></' +
-        prefix +
-        'X509Data>'
-      )
-    },
-  }
+  opts.embedKeyInfo &&
+    (sig.keyInfoProvider = {
+      getKeyInfo: (key, prefix) => {
+        prefix = prefix ? prefix + ':' : ''
+        return (
+          '<' +
+          prefix +
+          'X509Data><' +
+          prefix +
+          'X509Certificate>' +
+          pemToCert(cert) +
+          '</' +
+          prefix +
+          'X509Certificate></' +
+          prefix +
+          'X509Data>'
+        )
+      },
+    })
 
   sig.computeSignature(xml, {
     location: {

--- a/pages/idp.js
+++ b/pages/idp.js
@@ -44,6 +44,7 @@ export default function IdP(props) {
     signResponse: false,
     sigAlgo: 'rsa-sha1',
     digestAlgo: 'sha1',
+    embedKeyInfo: true,
   })
   const [sendResponse, setSendResponse] = useState(true)
   const [sendRelayState, setSendRelayState] = useState(true)
@@ -289,6 +290,23 @@ export default function IdP(props) {
                     />
                   }
                   label="Sign Response"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={sigOpts.embedKeyInfo}
+                      onChange={(ev) =>
+                        setSigOpts({
+                          ...sigOpts,
+                          embedKeyInfo: ev.target.checked,
+                        })
+                      }
+                      disabled={!sendResponse}
+                      name="embedKeyInfo"
+                      color="primary"
+                    />
+                  }
+                  label="Embed KeyInfo"
                 />
                 <FormControl variant="standard" className={styles.select}>
                   <InputLabel id="sig-algo">Signature Algorithm</InputLabel>


### PR DESCRIPTION
It's useful to be able to test scenarios where KeyInfo is not provided and the SP must rely on the public key they have stored, rather than a thumbprint.

Embedded KeyInfo is optional in the SAML spec

<img width="1003" height="251" alt="image" src="https://github.com/user-attachments/assets/c3d248ea-2a1c-4d6c-9398-281aa7929a3a" />
